### PR TITLE
Fix TypeScript build error: Add missing 'error' prop to DeleteConfirmModal

### DIFF
--- a/components/admin/delete-confirm-modal.tsx
+++ b/components/admin/delete-confirm-modal.tsx
@@ -11,6 +11,7 @@ interface DeleteConfirmModalProps {
   onConfirm: () => void
   productName: string
   isLoading?: boolean
+  error?: string | null
 }
 
 const DeleteConfirmModal = ({ 
@@ -18,7 +19,8 @@ const DeleteConfirmModal = ({
   onClose, 
   onConfirm, 
   productName,
-  isLoading = false 
+  isLoading = false,
+  error = null
 }: DeleteConfirmModalProps) => {
 
   const handleClose = () => {
@@ -78,6 +80,13 @@ const DeleteConfirmModal = ({
                 This action cannot be undone. The product will be permanently removed from your store.
               </p>
             </div>
+
+            {/* Error Message */}
+            {error && (
+              <div className="mb-4 bg-red-50 border border-red-200 rounded-lg p-3">
+                <p className="text-sm text-red-800">{error}</p>
+              </div>
+            )}
 
             {/* Buttons */}
             <div className="flex gap-2">


### PR DESCRIPTION
## 🐛 Fix TypeScript Build Error

### Problem
Vercel build was failing due to a TypeScript error in `admin-product-controls.tsx` line 157:
```
Property 'error' does not exist on type 'IntrinsicAttributes & DeleteConfirmModalProps'
```

The `DeleteConfirmModal` component was being passed an `error` prop that wasn't defined in its TypeScript interface.

### Solution
✅ **Added `error?: string | null` prop to `DeleteConfirmModalProps` interface**
✅ **Updated component to accept and handle the error prop**  
✅ **Added error message UI in the modal with proper styling**
✅ **Maintains all existing functionality**

### Changes Made
- Updated `DeleteConfirmModalProps` interface to include optional `error` prop
- Modified component function signature to accept the `error` parameter
- Added error message display in modal UI with consistent styling
- Error messages appear in a red-bordered container above the action buttons

### Testing
- ✅ TypeScript compilation now passes for the specific error
- ✅ Component maintains backward compatibility (error prop is optional)
- ✅ Error messages display properly when provided
- ✅ Modal functions normally when no error is present

### Impact
- 🚀 **Fixes Vercel build failure**
- 🎯 **Resolves the specific TypeScript error mentioned**
- 🔧 **Improves error handling UX in delete confirmation modal**
- ✨ **No breaking changes - fully backward compatible**

Ready for review and merge to resolve the build issue! 🎉