### PR TITLE
Fix: Remove leftover selectedMaterials reference causing TypeScript error

### DIFF
--- a/components/products/products-filter.tsx
+++ b/components/products/products-filter.tsx
@@ -81,7 +81,7 @@ const ProductsFilter = ({ currentCategory }: ProductsFilterProps) => {
     router.push(queryString ? `${basePath}?${queryString}` : basePath)
   }
 
-  const activeFiltersCount = selectedMaterials.length + 
+  const activeFiltersCount = 
     (inStockOnly ? 1 : 0) + 
     (featuredOnly ? 1 : 0) + 
     (priceRange[0] > 0 || priceRange[1] < 100 ? 1 : 0)


### PR DESCRIPTION
## 🐛 Fix: Error de compilación TypeScript

### Problema
- Error de compilación en Vercel en `components/products/products-filter.tsx` línea 84
- Referencia a `selectedMaterials` que no existe después de la limpieza de campos de materiales
- Error específico: `Cannot find name 'selectedMaterials'`

### Solución
- ✅ Eliminada la referencia `selectedMaterials.length` del cálculo de `activeFiltersCount`
- ✅ Corregido el cálculo para incluir solo los filtros existentes:
  - `inStockOnly`
  - `featuredOnly` 
  - `priceRange`

### Cambios realizados
```diff
- const activeFiltersCount = selectedMaterials.length + 
+ const activeFiltersCount = 
    (inStockOnly ? 1 : 0) + 
    (featuredOnly ? 1 : 0) + 
    (priceRange[0] > 0 || priceRange[1] < 100 ? 1 : 0)
```

### Verificación
- ✅ No quedan más referencias a `selectedMaterials` en el archivo
- ✅ El cálculo de filtros activos funciona correctamente
- ✅ Debería resolver el error de build en Vercel

### Tipo de cambio
- [x] Bug fix (cambio que corrige un problema)
- [ ] Nueva funcionalidad
- [ ] Breaking change
- [ ] Actualización de documentación