### PR TITLE
Fix: Add isAdmin property to AuthState (TypeScript build error)

### DIFF
--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, ReactNode } from 'react'
 interface AuthState {
   isAuthenticated: boolean
   user: null
+  isAdmin: boolean
 }
 
 const AuthContext = createContext<AuthState | null>(null)
@@ -13,7 +14,8 @@ const AuthContext = createContext<AuthState | null>(null)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const authState: AuthState = {
     isAuthenticated: false,
-    user: null
+    user: null,
+    isAdmin: false
   }
 
   return (


### PR DESCRIPTION
## 🐛 Fix TypeScript Build Error

### Problem
The Vercel deployment was failing with a TypeScript error:
```
Property 'isAdmin' does not exist on type 'AuthState'
```

This error occurred in `./components/admin/admin-product-controls.tsx:22:11` where the component was trying to destructure `isAdmin` from `useAuth()`, but the `AuthState` interface didn't include this property.

### Solution
- ✅ Added `isAdmin: boolean` property to the `AuthState` interface
- ✅ Updated the `AuthProvider` to include `isAdmin: false` as the default value
- ✅ Maintains backward compatibility with existing code

### Changes Made
- **File**: `contexts/auth-context.tsx`
  - Extended `AuthState` interface to include `isAdmin` property
  - Updated default auth state object to include `isAdmin: false`

### Testing
- The TypeScript error should now be resolved
- The Vercel build should pass successfully
- Admin controls will be hidden by default (isAdmin: false) until proper authentication logic is implemented

### Notes
This fix provides the missing TypeScript definition. Future work may involve implementing actual admin authentication logic to properly set the `isAdmin` value based on user roles.